### PR TITLE
fix(RefillUnit): modify cancel condition for refillEntry

### DIFF
--- a/src/main/scala/openLLC/MainPipe.scala
+++ b/src/main/scala/openLLC/MainPipe.scala
@@ -373,6 +373,7 @@ class MainPipe(implicit p: Parameters) extends LLCModule with HasCHIOpcodes {
   refill_s4.bits.task.replSnp := replace_snoop_s4
   refill_s4.bits.dirResult.self := selfDirResp_s4
   refill_s4.bits.dirResult.clients := clientsDirResp_s4
+  refill_s4.bits.isWrite := writeBackFull_s4 || writeEvictOrEvict_s4
 
   /** Comp task to ResponseUnit **/
   val respSC_s4 = sharedReq_s4


### PR DESCRIPTION
In the previous design, data returned by WriteEvictOrEvict transactions was not correctly written back to the cache, leading to a reduced hit rate.