### PR TITLE
fix(TestTop): parse l2hintParams to bundle L2ToL1Hint

### DIFF
--- a/src/test/scala/TestTop.scala
+++ b/src/test/scala/TestTop.scala
@@ -206,12 +206,11 @@ class TestTopSoC(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, issue:
       val clean = Input(Bool())
     })
 
-    val l2hintParams: Parameters = p.alterPartial {
-      case EdgeInKey => l2_nodes(0).node.in.head._2
-    }
-    val io_l1 = IO(Vec(numCores, new Bundle() {
-      val l2Hint = Valid(new L2ToL1Hint()(l2hintParams))
-    }))
+    val io_l1 = (l2_nodes.map { l2_node =>
+      IO(new Bundle {
+        val l2Hint = Valid(new L2ToL1Hint()(p.alterPartial { case EdgeInKey => l2_node.node.in.head._2 }))
+      })
+    })
 
     val cycle = RegInit(0.U(64.W))
     cycle := cycle + 1.U

--- a/src/test/scala/TestTop.scala
+++ b/src/test/scala/TestTop.scala
@@ -206,8 +206,11 @@ class TestTopSoC(numCores: Int = 1, numULAgents: Int = 0, banks: Int = 1, issue:
       val clean = Input(Bool())
     })
 
+    val l2hintParams: Parameters = p.alterPartial {
+      case EdgeInKey => l2_nodes(0).node.in.head._2
+    }
     val io_l1 = IO(Vec(numCores, new Bundle() {
-      val l2Hint = Valid(new L2ToL1Hint)
+      val l2Hint = Valid(new L2ToL1Hint()(l2hintParams))
     }))
 
     val cycle = RegInit(0.U(64.W))


### PR DESCRIPTION
After timing fix, sourceId in bundle L2ToL1Hint will rely on EdgeInKey from upper node, so parse it through l2hintParams